### PR TITLE
Minor cleanup of code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CFLAGS  += -flto
 LDFLAGS += -flto
 endif
 
-ifeq ($(32),y)
+ifeq ($(M32),y)
 CFLAGS  += -m32 -mregparm=3 -fno-plt -freg-struct-return
 LDFLAGS += -m32
 else

--- a/include/boot.h
+++ b/include/boot.h
@@ -50,10 +50,10 @@ typedef struct __packed sl_header {
 extern sl_header_t sl_header;
 
 typedef struct __packed skl_info {
-       u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
-       u32 version;
-       u16 msb_key_algo;
-       u8  msb_key_hash[64]; /* Support up to SHA512 */
+    u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
+    u32 version;
+    u16 msb_key_algo;
+    u8  msb_key_hash[64]; /* Support up to SHA512 */
 } skl_info_t;
 extern skl_info_t skl_info;
 

--- a/include/multiboot2.h
+++ b/include/multiboot2.h
@@ -35,11 +35,6 @@
 
 #ifndef __ASSEMBLY__
 
-typedef unsigned char           u8;
-typedef unsigned short          u16;
-typedef unsigned int            u32;
-typedef unsigned long long      u64;
-
 struct multiboot_tag
 {
     u32 type;

--- a/include/pci.h
+++ b/include/pci.h
@@ -47,7 +47,7 @@
 #define PCI_SLOT(devfn)         (((devfn) >> 3) & 0x1f)
 #define PCI_FUNC(devfn)         ((devfn) & 0x07)
 
-#define INVALID_CAP(c)      ((c == 0) || (c == 0xFFFFFFFF) || (c == 0xFF))
+#define INVALID_CAP(c)          ((c == 0) || (c == 0xFFFFFFFF) || (c == 0xFF))
 
 
 /* From arch/x86/pci/direct.c definitions */

--- a/include/tags.h
+++ b/include/tags.h
@@ -20,23 +20,23 @@ struct setup_data {
     struct setup_indirect indirect;
 } __packed;
 
-#define SKL_TAG_CLASS_MASK  0xF0
+#define SKL_TAG_CLASS_MASK       0xF0
 
 /* Tags with no particular class */
-#define SKL_TAG_NO_CLASS        0x00
-#define SKL_TAG_END     0x00
-#define SKL_TAG_SETUP_INDIRECT  0x01
-#define SKL_TAG_TAGS_SIZE   0x0F    /* Always first */
+#define SKL_TAG_NO_CLASS         0x00
+#define SKL_TAG_END              0x00
+#define SKL_TAG_SETUP_INDIRECT   0x01
+#define SKL_TAG_TAGS_SIZE        0x0F    /* Always first */
 
 /* Tags specifying kernel type */
-#define SKL_TAG_BOOT_CLASS  0x10
-#define SKL_TAG_BOOT_LINUX  0x10
-#define SKL_TAG_BOOT_MB2        0x11
+#define SKL_TAG_BOOT_CLASS       0x10
+#define SKL_TAG_BOOT_LINUX       0x10
+#define SKL_TAG_BOOT_MB2         0x11
 
 /* Tags specific to TPM event log */
-#define SKL_TAG_EVENT_LOG_CLASS 0x20
-#define SKL_TAG_EVENT_LOG   0x20
-#define SKL_TAG_SKL_HASH        0x21
+#define SKL_TAG_EVENT_LOG_CLASS  0x20
+#define SKL_TAG_EVENT_LOG        0x20
+#define SKL_TAG_SKL_HASH         0x21
 
 struct skl_tag_hdr {
     u8 type;

--- a/include/types.h
+++ b/include/types.h
@@ -53,14 +53,15 @@ typedef short               s16;
 typedef int                 s32;
 typedef long long           s64;
 
-typedef unsigned long   uintptr_t;
+typedef unsigned long       uintptr_t;
 
-typedef unsigned long   size_t;
-typedef long            ssize_t;
+typedef unsigned long       size_t;
+typedef long                ssize_t;
 
-typedef _Bool           bool;
+typedef _Bool               bool;
 
 #define NULL ((void *)0)
 
 #endif /* __STDC_HOSTED__ */
+
 #endif /* __TYPES_H__ */


### PR DESCRIPTION
 - Remove duplicate definitions
 - Use consistent indenting
 - Use M32 to build 32b SKL (shells don't like 32=y)

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>