### PR TITLE
Add support for simple payloads

### DIFF
--- a/head.S
+++ b/head.S
@@ -180,8 +180,12 @@ GLOBAL(_entry)
 	push	$0
 	popf
 
-	cmpl	$MULTIBOOT2, boot_protocol(%ebp)
+	mov	boot_protocol(%ebp), %edx
+	cmp	$MULTIBOOT2, %edx
 	je	multiboot2_kernel
+
+	cmp	$SIMPLE_PAYLOAD, %edx
+	je	simple_payload
 
 	/* Jump to entry target - EBX: startup_32, ESI: ZP base, EDX: SKL base */
 	mov	%ebp, %edx
@@ -192,6 +196,12 @@ multiboot2_kernel:
 	xchg	%esi, %ebx
 	mov	$MULTIBOOT2_BOOTLOADER_MAGIC, %eax
 	jmp *%esi
+
+simple_payload:
+	/* Jump to entry target - argument and dummy return address on stack */
+	push	%esi
+	push	$0
+	jmp	*%ebx
 ENDFUNC(_entry)
 
 	.data

--- a/include/defs.h
+++ b/include/defs.h
@@ -24,6 +24,7 @@
 #pragma GCC visibility push(hidden)
 
 #define LINUX_BOOT      0
+#define SIMPLE_PAYLOAD  1
 #define MULTIBOOT2      2
 
 #define STACK_CANARY    0xDEADBEEF

--- a/include/tags.h
+++ b/include/tags.h
@@ -32,6 +32,7 @@ struct setup_data {
 #define SKL_TAG_BOOT_CLASS       0x10
 #define SKL_TAG_BOOT_LINUX       0x10
 #define SKL_TAG_BOOT_MB2         0x11
+#define SKL_TAG_BOOT_SIMPLE      0x12
 
 /* Tags specific to TPM event log */
 #define SKL_TAG_EVENT_LOG_CLASS  0x20
@@ -58,6 +59,14 @@ struct skl_tag_boot_mb2 {
     u32 mbi;
     u32 kernel_entry;
     u32 kernel_size;
+} __packed;
+
+struct skl_tag_boot_simple_payload {
+    struct skl_tag_hdr hdr;
+    u32 base;
+    u32 size;
+    u32 entry;
+    u32 arg;
 } __packed;
 
 struct skl_tag_evtlog {

--- a/main.c
+++ b/main.c
@@ -445,6 +445,15 @@ static asm_return_t skl_multiboot2(struct tpm *tpm, struct skl_tag_boot_mb2 *skl
     return (asm_return_t){ kernel_entry, _p(skl_tag->mbi) };
 }
 
+static asm_return_t skl_simple_payload(struct tpm *tpm, struct skl_tag_boot_simple_payload *skl_tag)
+{
+    extend_pcr(tpm, _p(skl_tag->base), skl_tag->size, 17, "Measured payload into PCR17");
+
+    boot_protocol = SIMPLE_PAYLOAD;
+
+    return (asm_return_t){ _p(skl_tag->entry), _p(skl_tag->arg) };
+}
+
 asm_return_t skl_main(void)
 {
     asm_return_t ret;
@@ -500,6 +509,9 @@ asm_return_t skl_main(void)
         break;
     case SKL_TAG_BOOT_MB2:
         ret = skl_multiboot2(tpm, (struct skl_tag_boot_mb2 *)t);
+        break;
+    case SKL_TAG_BOOT_SIMPLE:
+        ret = skl_simple_payload(tpm, (struct skl_tag_boot_simple_payload *)t);
         break;
     default:
         print("Unknown kernel boot protocol\n");


### PR DESCRIPTION
This adds new SKL tag to allow for booting simplest payload. Tag contains base and size of the payload, its entry point and a single argument. SKL extends just the payload to PCR17, and argument is not used except for passing it to the payload using cdecl convention. It is the responsibility of the payload to measure this argument before using. Payload also has to set GIF at appropriate time, as well as not use INIT for starting APs, as usual.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>
Reviewed-by: Ross Philipson <ross.philipson@oracle.com>
Reviewed-by: Daniel P. Smith <dpsmith@apertussolutions.com>