### PR TITLE
CodeQL

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 12 * * 3' # Weekly, Wed at 12:30 pm
+
+jobs:
+  CodeQL:
+
+    strategy:
+      matrix:
+        bits: ['32', '64']
+        lto: [LTO=y, LTO=n]
+
+    runs-on: 'ubuntu-22.04'
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: github/codeql-action/init@v2
+      with:
+        languages: cpp
+        queries: security-and-quality
+
+    - name: Build
+      run: |
+        make BITS=${{matrix.bits}} ${{matrix.lto}}
+
+    - uses: github/codeql-action/analyze@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc-9, gcc-10, gcc-11, clang-12, clang-13, clang-14]
-        bits: [32, 64]
+        bits: ['32', '64']
         lto: [LTO=y, LTO=n]
 
     runs-on: 'ubuntu-22.04'
@@ -23,5 +23,5 @@ jobs:
 
     - name: make
       run: |
-        make CC=${{matrix.compiler}} M32=${{matrix.bits == 32 && 'y' || 'n'}} ${{matrix.lto}}
+        make CC=${{matrix.compiler}} BITS=${{matrix.bits}} ${{matrix.lto}}
         ./extend_skl_only.sh

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        bits: [32, 64]
+        bits: ['32', '64']
         lto: [LTO=y, LTO=n]
 
     runs-on: 'ubuntu-22.04'
@@ -22,4 +22,4 @@ jobs:
 
     - name: make
       run: |
-        scan-build-14 --status-bugs -analyze-headers make M32=${{matrix.bits == 32 && 'y' || 'n'}} ${{matrix.lto}}
+        scan-build-14 --status-bugs -analyze-headers make BITS=${{matrix.bits}} ${{matrix.lto}}

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,15 @@ CFLAGS  += -flto
 LDFLAGS += -flto
 endif
 
-ifeq ($(M32),y)
+BITS ?= 64
+ifeq ($(BITS),32)
 CFLAGS  += -m32 -mregparm=3 -fno-plt -freg-struct-return
 LDFLAGS += -m32
-else
+else ifeq ($(BITS),64)
 CFLAGS  += -m64
 LDFLAGS += -m64
+else
+$(error Bad $$(BITS) value '$(BITS)')
 endif
 
 # There is a 64k total limit, so optimise for size.  The binary may be loaded

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 TrenchBoot Secure Kernel Loader
 ===============================
 
-[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/TrenchBoot/secure-kernel-loader.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/TrenchBoot/secure-kernel-loader/context:cpp)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/TrenchBoot/secure-kernel-loader.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/TrenchBoot/secure-kernel-loader/alerts/)
-
 Open source implementation of Secure Loader for AMD Secure Startup.

--- a/main.c
+++ b/main.c
@@ -552,18 +552,15 @@ asm_return_t skl_main(void)
 
 static void __maybe_unused build_assertions(void)
 {
-    struct boot_params b;
-    struct kernel_info k;
+    BUILD_BUG_ON(offsetof(struct boot_params, tb_dev_map)        != 0x0d8);
+    BUILD_BUG_ON(offsetof(struct boot_params, syssize)           != 0x1f4);
+    BUILD_BUG_ON(offsetof(struct boot_params, version)           != 0x206);
+    BUILD_BUG_ON(offsetof(struct boot_params, code32_start)      != 0x214);
+    BUILD_BUG_ON(offsetof(struct boot_params, cmd_line_ptr)      != 0x228);
+    BUILD_BUG_ON(offsetof(struct boot_params, cmdline_size)      != 0x238);
+    BUILD_BUG_ON(offsetof(struct boot_params, payload_offset)    != 0x248);
+    BUILD_BUG_ON(offsetof(struct boot_params, payload_length)    != 0x24c);
+    BUILD_BUG_ON(offsetof(struct boot_params, kern_info_offset)  != 0x268);
 
-    BUILD_BUG_ON(offsetof(typeof(b), tb_dev_map)        != 0x0d8);
-    BUILD_BUG_ON(offsetof(typeof(b), syssize)           != 0x1f4);
-    BUILD_BUG_ON(offsetof(typeof(b), version)           != 0x206);
-    BUILD_BUG_ON(offsetof(typeof(b), code32_start)      != 0x214);
-    BUILD_BUG_ON(offsetof(typeof(b), cmd_line_ptr)      != 0x228);
-    BUILD_BUG_ON(offsetof(typeof(b), cmdline_size)      != 0x238);
-    BUILD_BUG_ON(offsetof(typeof(b), payload_offset)    != 0x248);
-    BUILD_BUG_ON(offsetof(typeof(b), payload_length)    != 0x24c);
-    BUILD_BUG_ON(offsetof(typeof(b), kern_info_offset)  != 0x268);
-
-    BUILD_BUG_ON(offsetof(typeof(k), mle_header_offset) != 0x010);
+    BUILD_BUG_ON(offsetof(struct kernel_info, mle_header_offset) != 0x010);
 }


### PR DESCRIPTION
Several RFCs here.

* Are we happy swapping M32=y/n for BITS=32/64 in the first place?  I can fix the CodeQL bug while retaining M32= but I don't really like leaving M32= in place.
* Do we want to run security-and-quality (i.e. everything) by default?  It shows up 40 issues, most of which I think are false positives, but can probably be fixed by doing certain things in more standard ways.

@dpsmith Along with merging this, we should disable the LGTM plugin for the repo.

https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/  for full info.