### PR TITLE
iommu.c: rework initialization function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,7 @@ jobs:
       run: |
         make CC=${{matrix.compiler}} BITS=${{matrix.bits}} ${{matrix.lto}}
         ./extend_skl_only.sh
+
+    - name: make tests
+      run: |
+        make CC=${{matrix.compiler}} BITS=64 ${{matrix.lto}} tests

--- a/include/iommu.h
+++ b/include/iommu.h
@@ -28,6 +28,7 @@
 #define IOMMU_DTE_Q0_IW			(1ULL << 62)
 
 #define IOMMU_DTE_Q1_I			(1ULL << (96 - 64))
+#define IOMMU_DTE_Q1_SE			(1ULL << (97 - 64))
 
 #define IOMMU_DTE_Q2_IV			(1ULL << (128 - 128))
 #define IOMMU_DTE_Q2_IG			(1ULL << (133 - 128))
@@ -78,8 +79,7 @@
 #define IOMMU_CR_BlkStopMrkEn		(1ULL << 41)
 #define IOMMU_CR_PprAutoRspAon		(1ULL << 42)
 
-#define IOMMU_CR_ENABLE_ALL_MASK	(IOMMU_CR_IommuEn | \
-					 IOMMU_CR_HtTunEn | \
+#define IOMMU_CR_ENABLE_ALL_MASK	(IOMMU_CR_HtTunEn | \
 					 IOMMU_CR_EventLogEn | \
 					 IOMMU_CR_EventIntEn | \
 					 IOMMU_CR_ComWaitIntEn | \
@@ -103,6 +103,8 @@
 					 IOMMU_CR_PprAutoRspAon)
 
 #define IOMMU_EF_IASup			(1ULL << 6)
+
+#define IOMMU_SR_EventLogInt		(1ULL << 1)
 
 #define COMPLETION_WAIT			1
 #define INVALIDATE_DEVTAB_ENTRY		2
@@ -135,6 +137,6 @@ extern iommu_command_t command_buf[2];
 void disable_memory_protection(void);
 
 u32 iommu_locate(void);
-u32 iommu_load_device_table(u32 cap, volatile u64 *completed);
+int iommu_init(u32 cap);
 
 #endif /* __IOMMU_H__ */

--- a/include/string.h
+++ b/include/string.h
@@ -3,26 +3,31 @@
 
 #if __STDC_HOSTED__
 
-#include <string.h>	/* memcpy, memset */
+#include <string.h>	/* memcpy, memset, memcmp */
+
+/* Used in tests only */
+#define memcmp(l, r, n) __builtin_memcmp(l, r, n)
 
 #else
 
+/* Local declaration of bits of libc */
+
+void *memset(void *s, int c, size_t n);
+
+void *memcpy(void *dst, const void *src, size_t n);
+
+size_t strlen(const char *s);
+
+#endif /* __STDC_HOSTED__ */
+
 /*
- * Local declaration of bits of libc
- *
  * Use __builtin_???() wherever possible to allow the compiler to perform
  * optimisations (e.g. constant folding) where possible.  Calls to ???() will
  * be emitted as needed.
  */
 
-void *memset(void *s, int c, size_t n);
 #define memset(d, c, n) __builtin_memset(d, c, n)
-
-void *memcpy(void *dst, const void *src, size_t n);
 #define memcpy(d, s, n) __builtin_memcpy(d, s, n)
-
-size_t strlen(const char *s);
 #define strlen(s)       __builtin_strlen(s)
 
-#endif /* __STDC_HOSTED__ */
 #endif /* __STRINGS_H__ */


### PR DESCRIPTION
Test for INVALIDATE_ALL completion is now done inside the initialization function, instead of main.c. Function names were changed to better describe what the function does. Comment describing window in anti-DMA security was updated with new finds.

Two bugs were fixed:
- EventLogInt wasn't properly cleared (it is write-1-to-clear bit)
- CmdBufEn was set on transition to the kernel, which didn't clear it before setting up head/tail pointers, which in turn lead to hang (it is listed as undefined behavior in IOMMU specification)