### PR TITLE
head.S: move skl_info and bootloader_data fields back

### DIFF
--- a/head.S
+++ b/head.S
@@ -48,8 +48,6 @@ GLOBAL(sl_header)
 	.long	0xffffffff       /* Reserved */
 	.long	_end_of_signed + 0x640 /* Total Length including signature and pubkey raw data */
 	.word	soc_flag         /* Offset to SOCFLAG Structure, see below */
-	.word	skl_info         /* Offset to SKL info with UUID and version */
-	.word	bootloader_data  /* Offset to SLRT filled by the bootloader */
 
 soc_flag:
 	/*
@@ -66,6 +64,8 @@ soc_flag:
 	.long	0x00a10f00
 	.long	0x00a80f00
 	.long	0x00aa0f00
+	.word	skl_info         /* Offset to SKL info with UUID and version */
+	.word	bootloader_data  /* Offset to SLRT filled by the bootloader */
 ENDDATA(sl_header)
 
 	.text

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . util.sh
 
-SKL_INFO=`hexdump "$SLB_FILE" -s30 -n2 -e '/2 "%u"'`
+SKL_INFO=`hexdump "$SLB_FILE" -s66 -n2 -e '/2 "%u"'`
 
 if ! od --format=x8 --skip-bytes=$SKL_INFO --read-bytes=16 $SLB_FILE | grep -q "e91192048e26f178 02ccc4765bc82a83"; then
     echo "ERROR: SKL UUID missing or misplaced in $SLB_FILE" >&2


### PR DESCRIPTION
Fixes issue:

```
loader/slaunch/skl.c:117:slaunch: Possible SKL module measures bootloader data:
16424 (measured prefix) > 170 (data offset)
error: SKL module isn't correct.
```

Tested with `tb-dev` GRUB (`meta-trenchboot`)